### PR TITLE
New optional `title` property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@ export default class ReactCountryFlag extends Component {
         cdnUrl: PropTypes.string,
         code: PropTypes.string.isRequired,
         styleProps: PropTypes.object,
-        svg: PropTypes.bool
+        svg: PropTypes.bool,
+        title: PropTypes.string
     };
 
     static defaultProps = {
@@ -16,7 +17,7 @@ export default class ReactCountryFlag extends Component {
     };
 
     render() {
-        const { cdnUrl, code, styleProps, svg } = this.props;
+        const { cdnUrl, code, styleProps, svg, title } = this.props;
 
         const flagUrl = `${cdnUrl}${code.toLowerCase()}.svg`;
         const emoji = code
@@ -43,7 +44,7 @@ export default class ReactCountryFlag extends Component {
                     verticalAlign: "middle",
                     ...styleProps
                 }}
-                title={code}
+                title={title || code}
             />
         ) : (
             <span


### PR DESCRIPTION
This overrides the default `title` which is the country's code.

This might be useful for those who want to set the title to the plain text local name of the country instead of the iso3361 code.