### PR TITLE
Add optional className property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 export default class ReactCountryFlag extends Component {
     static propTypes = {
         cdnUrl: PropTypes.string,
+        className: PropTypes.string,
         code: PropTypes.string.isRequired,
         styleProps: PropTypes.object,
         svg: PropTypes.bool,
@@ -17,7 +18,7 @@ export default class ReactCountryFlag extends Component {
     };
 
     render() {
-        const { cdnUrl, code, styleProps, svg, title } = this.props;
+        const { cdnUrl, className, code, styleProps, svg, title } = this.props;
 
         const flagUrl = `${cdnUrl}${code.toLowerCase()}.svg`;
         const emoji = code
@@ -29,6 +30,7 @@ export default class ReactCountryFlag extends Component {
         return svg ? (
             <span
                 aria-label={code}
+                className={className}
                 role="img"
                 style={{
                     position: "relative",
@@ -49,6 +51,7 @@ export default class ReactCountryFlag extends Component {
         ) : (
             <span
                 aria-label={code}
+                className={className}
                 role="img"
                 style={{
                     verticalAlign: "middle",


### PR DESCRIPTION
This adds optional className property, allowing to override the styling of the root "span" element using classes.

I know there already is "styleProps" property, but others might prefer to use classes instead of setting styles directly.

Closes #14.